### PR TITLE
chore: add return type typings

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,3 @@
 export * from "./internals/api";
+export * from "./internals/interfaces";
+export * from "./internals/returnTypes";

--- a/dist/internals/api.d.ts
+++ b/dist/internals/api.d.ts
@@ -1,3 +1,4 @@
+import { AbsenceReturnType, AbsencesReturnType, DeleteReturnType, CustomerReturnType, CustomersReturnType, ProjectReturnType, ServiceReturnType, ServicesReturnType, UserReturnType, UsersReturnType, EntryReturnType, EntriesReturnType, TasksReturnType, TaskDurationReturnType, DeleteEntryGroupsReturnType, EditEntryGroupsReturnType, UserReportReturnType, UserReportsReturnType, ClockReturnType, ClockUpdateReturnType, ClockEditReturnType, ClockStopReturnType, TargetHoursReturnType, TargetHourReturnType, AddUserReturnType, SearchTextsReturnType, EntryGroupsReturnType } from "../internals/returnTypes";
 export declare const ENTRY_UNBILLABLE = 0;
 export declare const ENTRY_BILLABLE = 1;
 export declare const ENTRY_BILLED = 2;
@@ -28,141 +29,141 @@ export declare class Clockodo {
     });
     getAbsence({ id }: {
         id: string;
-    }): Promise<any>;
+    }): AbsenceReturnType;
     getAbsences({ year }: {
         year: number;
-    }): Promise<any>;
-    getClock(): Promise<any>;
-    getClockUpdate(): Promise<any>;
+    }): AbsencesReturnType;
+    getClock(): ClockReturnType;
+    getClockUpdate(): ClockUpdateReturnType;
     getCustomer({ id }: {
         id: string;
-    }): Promise<any>;
-    getCustomers(): Promise<any>;
+    }): CustomerReturnType;
+    getCustomers(): CustomersReturnType;
     getEntry({ id }: {
         id: string;
-    }): Promise<any>;
+    }): EntryReturnType;
     getEntries({ timeSince, timeUntil }: {
         timeSince: string;
         timeUntil: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): EntriesReturnType;
     getEntryGroups({ timeSince, timeUntil, grouping }: {
         timeSince: string;
         timeUntil: string;
         grouping: string[];
-    }, options?: object): Promise<any>;
+    }, options?: object): EntryGroupsReturnType;
     getProject({ id }: {
         id: string;
-    }): Promise<any>;
-    getSearchTexts(options?: object): Promise<any>;
+    }): ProjectReturnType;
+    getSearchTexts(options?: object): SearchTextsReturnType;
     getService({ id }: {
         id: string;
-    }): Promise<any>;
-    getServices(): Promise<any>;
+    }): ServiceReturnType;
+    getServices(): ServicesReturnType;
     getSingleTargetHourSet({ id }: {
         id: string;
-    }): Promise<any>;
-    getTargetHours(options?: object): Promise<any>;
+    }): TargetHourReturnType;
+    getTargetHours(options?: object): TargetHoursReturnType;
     getTaskDuration({ taskCustomerId, taskProjectId, taskServiceId, taskText, taskBillable, }: {
         taskCustomerId: string;
         taskProjectId: string;
         taskServiceId: string;
         taskText: string;
         taskBillable: Billable;
-    }, options?: object): Promise<any>;
-    getTasks(options?: object): Promise<any>;
+    }, options?: object): TaskDurationReturnType;
+    getTasks(options?: object): TasksReturnType;
     getUser({ id }: {
         id: string;
-    }): Promise<any>;
-    getUsers(): Promise<any>;
+    }): UserReturnType;
+    getUsers(): UsersReturnType;
     getUserReport({ id, year }: {
         id: string;
         year: number;
-    }, options?: object): Promise<any>;
+    }, options?: object): UserReportReturnType;
     getUserReports({ year }: {
         year: number;
-    }, options?: object): Promise<any>;
+    }, options?: object): UserReportsReturnType;
     changeClockDuration({ entryId, durationBefore, duration }: {
         entryId: string;
         durationBefore: number;
         duration: number;
-    }, options?: object): Promise<any>;
+    }, options?: object): ClockEditReturnType;
     startClock({ customerId, serviceId, billable }: {
         customerId: string;
         serviceId: string;
         billable: Billable;
-    }, options?: object): Promise<any>;
+    }, options?: object): ClockReturnType;
     addCustomer({ name }: {
         name: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): CustomerReturnType;
     addProject({ name, customerId }: {
         name: string;
         customerId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ProjectReturnType;
     addService({ name }: {
         name: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ServiceReturnType;
     addUser({ name, number, email, role }: {
         name: string;
         number: string;
         email: string;
         role: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): AddUserReturnType;
     addEntry({ customerId, serviceId, billable }: {
         customerId: string;
         serviceId: string;
         billable: Billable;
-    }, options?: object): Promise<any>;
+    }, options?: object): EntryReturnType;
     addAbsence({ dateSince, dateUntil, type }: {
         dateSince: string;
         dateUntil: string;
         type: AbsenceType;
-    }, options?: object): Promise<any>;
+    }, options?: object): AbsenceReturnType;
     stopClock({ entryId }: {
         entryId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ClockStopReturnType;
     deactivateCustomer({ customerId }: {
         customerId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): CustomerReturnType;
     deactivateProject({ projectId }: {
         projectId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ProjectReturnType;
     deactivateService({ serviceId }: {
         serviceId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ServiceReturnType;
     deactivateUser({ userId }: {
         userId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): UserReturnType;
     deleteEntry({ entryId }: {
         entryId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): DeleteReturnType;
     deleteEntryGroup({ timeSince, timeUntil }: {
         timeSince: string;
         timeUntil: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): DeleteEntryGroupsReturnType;
     deleteAbsence({ absenceId }: {
         absenceId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): DeleteReturnType;
     editCustomer({ customerId }: {
         customerId: string;
     }, options?: object): Promise<any>;
     editProject({ projectId }: {
         projectId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ProjectReturnType;
     editService({ serviceId }: {
         serviceId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): ServiceReturnType;
     editUser({ userId }: {
         userId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): UserReturnType;
     editEntryGroup({ timeSince, timeUntil }: {
         timeSince: string;
         timeUntil: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): EditEntryGroupsReturnType;
     editAbsence({ absenceId }: {
         absenceId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): AbsenceReturnType;
     editEntry({ entryId }: {
         entryId: string;
-    }, options?: object): Promise<any>;
+    }, options?: object): EntryReturnType;
 }
 export {};

--- a/dist/internals/interfaces.d.ts
+++ b/dist/internals/interfaces.d.ts
@@ -9,7 +9,7 @@ export interface Customer {
 }
 export interface Project {
     id: number;
-    customerId: number;
+    customersId: number;
     name: string;
     active: boolean;
     billableDefault: boolean;
@@ -40,13 +40,13 @@ export interface User {
 }
 export interface Entry {
     id: number;
-    customerId: number;
-    projectId: number;
-    userId: number;
-    serviceId: number;
+    customersId: number;
+    projectsId: number;
+    usersId: number;
+    servicesId: number;
     billable: 0 | 1;
     billed: boolean;
-    textId: number;
+    textsId: number;
     text: string;
     duration: number;
     durationTime: string;
@@ -72,14 +72,14 @@ export interface Entry {
 }
 export interface Task {
     day: string;
-    customerId: number;
-    customerName: string;
-    projectId: number;
-    projectName: string;
-    serviceId: number;
-    serviceName: string;
+    customersId: number;
+    customersName: string;
+    projectsId: number;
+    projectsName: string;
+    servicesId: number;
+    servicesName: string;
     billable: number;
-    textId: number;
+    textsId: number;
     text: string;
     duration: number;
     durationTime: string;
@@ -110,8 +110,8 @@ export interface EntryGroup {
     subGroups: EntryGroup[];
 }
 export interface UserReport {
-    userId: number;
-    userName: string;
+    usersId: number;
+    usersName: string;
     sumTarget: number;
     sumHours: number;
     sumReductionUsed: number;
@@ -169,7 +169,7 @@ export interface UserReportDay {
 }
 export interface Absence {
     id: number;
-    userId: number;
+    usersId: number;
     dateSince: string;
     dateUntil: string;
     status: number;
@@ -183,7 +183,7 @@ export interface Absence {
 }
 export interface TargetHoursRow {
     id: number;
-    userId: number;
+    usersId: number;
     type: string;
     dateSince: string;
     dateUntil: string | null;
@@ -208,13 +208,13 @@ export interface TargetHoursRow {
 }
 export interface HolidayQuotasRow {
     id: number;
-    userId: number;
+    usersId: number;
     yearSince: number;
     yearUntil: number;
     count: number;
 }
 export interface HolidaysCarryRow {
-    userId: number;
+    usersId: number;
     year: number;
     count: number;
     note: string;
@@ -237,12 +237,12 @@ export interface Paging {
     countItems: number;
 }
 export interface Filter {
-    userId?: number;
-    customerId?: number;
-    projectId?: number;
-    serviceId?: number;
+    usersId?: number;
+    customersId?: number;
+    projectsId?: number;
+    servicesId?: number;
     billable?: number;
     text?: string;
-    textId?: number;
+    textsId?: number;
     budgetType?: string;
 }

--- a/dist/internals/interfaces.d.ts
+++ b/dist/internals/interfaces.d.ts
@@ -90,7 +90,7 @@ export interface Task {
 }
 export interface EntryGroup {
     groupeyby: string;
-    group: string;
+    group: string | number;
     name: string;
     number: string;
     note: string;

--- a/dist/internals/interfaces.d.ts
+++ b/dist/internals/interfaces.d.ts
@@ -1,0 +1,248 @@
+export interface Customer {
+    id: number;
+    name: string;
+    number: string;
+    active: boolean;
+    billableDefault: boolean;
+    note: string;
+    projects: Project[];
+}
+export interface Project {
+    id: number;
+    customerId: number;
+    name: string;
+    active: boolean;
+    billableDefault: boolean;
+    note: string;
+    budgetMoney: number;
+    budgetIsHours: boolean;
+    budgetIsNotStrict: boolean;
+    completed: boolean;
+    billedMoney: number;
+    billedCompletely: boolean;
+    revenueFactor: number;
+}
+export interface Service {
+    id: number;
+    name: string;
+    number: string;
+    active: boolean;
+    note: string;
+}
+export interface User {
+    id: number;
+    name: string;
+    number: string;
+    email: string;
+    role: string;
+    active: boolean;
+    editLock: string;
+}
+export interface Entry {
+    id: number;
+    customerId: number;
+    projectId: number;
+    userId: number;
+    serviceId: number;
+    billable: 0 | 1;
+    billed: boolean;
+    textId: number;
+    text: string;
+    duration: number;
+    durationTime: string;
+    offset: number;
+    offsetTime: string;
+    timeSince: string;
+    timeUntil: string;
+    timeInsert: string;
+    timeLastChange: string;
+    timeLastChangeWorktime: string;
+    clocked: boolean;
+    isClocking: boolean;
+    lumpSum: number;
+    hourlyRate?: number;
+    revenue?: number;
+    budget?: number;
+    budgetIsHours?: boolean;
+    budgetIsNotStrict?: boolean;
+    customerName?: string;
+    projectName?: string;
+    serviceName?: string;
+    userName?: string;
+}
+export interface Task {
+    day: string;
+    customerId: number;
+    customerName: string;
+    projectId: number;
+    projectName: string;
+    serviceId: number;
+    serviceName: string;
+    billable: number;
+    textId: number;
+    text: string;
+    duration: number;
+    durationTime: string;
+    durationText: string;
+    isClocking: boolean;
+    hasJustLumpSums: boolean;
+    revenue?: number;
+}
+export interface EntryGroup {
+    groupeyby: string;
+    group: string;
+    name: string;
+    number: string;
+    note: string;
+    restrictions: string[];
+    duration: number;
+    revenue?: number;
+    budgetUsed?: boolean;
+    hasBudgetRevenuesBilled?: boolean;
+    hasBudgetRevenuesNotBilled?: boolean;
+    hasNonBudgetRevenuesBilled?: boolean;
+    hasNonBudgetRevenuesNotBilled?: boolean;
+    hourlyRate?: number;
+    hourlyRateIsEqualAndHasNoLumpSums?: boolean;
+    durationWithoutRounding?: number;
+    revenueWithoutRounding?: number;
+    roundingSuccess?: boolean;
+    subGroups: EntryGroup[];
+}
+export interface UserReport {
+    userId: number;
+    userName: string;
+    sumTarget: number;
+    sumHours: number;
+    sumReductionUsed: number;
+    sumReductionPlanned: number;
+    overtimeCarryover: number;
+    overtimeReduced: number;
+    diff: number;
+    holidaysQuota: number;
+    holidaysCarry: number;
+    holidaysUsed: number;
+    specialHolidays: number;
+    sickdays: number;
+    monthDetails: UserReportMonth[];
+}
+export interface UserReportMonth {
+    nr: number;
+    sumTarget: number;
+    sumHours: number;
+    sumHoursWithoutCompensation: number;
+    sumReductionUsed: number;
+    sumOvertimeReduced: number;
+    diff: number;
+    weekDetails: UserReportWeek[];
+}
+export interface UserReportWeek {
+    nr: number;
+    sumTarget: number;
+    sumHours: number;
+    sumReductionUsed: number;
+    diff: number;
+    weekDetails: UserReportDay[];
+}
+export interface Break {
+    since: string;
+    until: string;
+    length: number;
+}
+export interface UserReportDay {
+    date: string;
+    weekday: number;
+    nonbusiness: boolean;
+    countSick: number;
+    countRegularHolidays: number;
+    countSpecialLeaves: number;
+    countHolidas: number;
+    countOtReductionUsed: number;
+    target: number;
+    targetRaw: number;
+    hours: number;
+    hoursWithoutCompensation: number;
+    diff: number;
+    workStart: string;
+    workEnd: string;
+    breaks: Break[];
+}
+export interface Absence {
+    id: number;
+    userId: number;
+    dateSince: string;
+    dateUntil: string;
+    status: number;
+    type: number;
+    note: string;
+    countDays: number;
+    countHours: number;
+    dateEnquired: string;
+    dateApproved: string;
+    approvedBy: number;
+}
+export interface TargetHoursRow {
+    id: number;
+    userId: number;
+    type: string;
+    dateSince: string;
+    dateUntil: string | null;
+    monday: number;
+    tuesday: number;
+    wednesday: number;
+    thursday: number;
+    friday: number;
+    saturday: number;
+    sunday: number;
+    absenceFixedCredit: boolean;
+    compensationDaily: number;
+    compensationMonthly: number;
+    monthlyTarget: number;
+    workdayMonday: boolean;
+    workdayTuesday: boolean;
+    workdayWednesday: boolean;
+    workdayThursday: boolean;
+    workdayFriday: boolean;
+    workdaySaturday: boolean;
+    workdaySunday: boolean;
+}
+export interface HolidayQuotasRow {
+    id: number;
+    userId: number;
+    yearSince: number;
+    yearUntil: number;
+    count: number;
+}
+export interface HolidaysCarryRow {
+    userId: number;
+    year: number;
+    count: number;
+    note: string;
+}
+export interface User {
+    name: string;
+    email: string;
+    role: string;
+    timeformat12h: boolean;
+    weekstartMonday: boolean;
+    language: string;
+    currency: string;
+    currencySymbol: string;
+    timezone: string;
+}
+export interface Paging {
+    itemsPerPage: number;
+    currentPage: number;
+    countPages: number;
+    countItems: number;
+}
+export interface Filter {
+    userId?: number;
+    customerId?: number;
+    projectId?: number;
+    serviceId?: number;
+    billable?: number;
+    text?: string;
+    textId?: number;
+    budgetType?: string;
+}

--- a/dist/internals/interfaces.d.ts
+++ b/dist/internals/interfaces.d.ts
@@ -65,10 +65,10 @@ export interface Entry {
     budget?: number;
     budgetIsHours?: boolean;
     budgetIsNotStrict?: boolean;
-    customerName?: string;
-    projectName?: string;
-    serviceName?: string;
-    userName?: string;
+    customersName?: string;
+    projectsName?: string;
+    servicesName?: string;
+    usersName?: string;
 }
 export interface Task {
     day: string;

--- a/dist/internals/interfaces.d.ts
+++ b/dist/internals/interfaces.d.ts
@@ -142,7 +142,7 @@ export interface UserReportWeek {
     sumHours: number;
     sumReductionUsed: number;
     diff: number;
-    weekDetails: UserReportDay[];
+    dayDetails: UserReportDay[];
 }
 export interface Break {
     since: string;

--- a/dist/internals/interfaces.js
+++ b/dist/internals/interfaces.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/internals/returnTypes.d.ts
+++ b/dist/internals/returnTypes.d.ts
@@ -1,0 +1,117 @@
+import { Absence, Customer, Project, Service, User, Entry, Paging, Filter, Task, EntryGroup, UserReport, TargetHoursRow } from "./interfaces";
+export declare type AbsenceReturnType = Promise<{
+    absence: Absence;
+}>;
+export declare type AbsencesReturnType = Promise<{
+    absences: Absence[];
+}>;
+export declare type DeleteReturnType = Promise<{
+    success: true;
+}>;
+export declare type CustomerReturnType = Promise<{
+    customer: Customer;
+}>;
+export declare type CustomersReturnType = Promise<{
+    customers: Customer[];
+}>;
+export declare type ProjectReturnType = Promise<{
+    project: Project;
+}>;
+export declare type ServiceReturnType = Promise<{
+    service: Service;
+}>;
+export declare type ServicesReturnType = Promise<{
+    services: Service[];
+}>;
+export declare type UserReturnType = Promise<{
+    user: User;
+}>;
+export declare type UsersReturnType = Promise<{
+    users: User[];
+}>;
+export declare type EntryReturnType = Promise<{
+    entry: Entry;
+}>;
+export declare type EntriesReturnType = Promise<{
+    paging: Paging;
+    filter: Filter | null;
+    entries: Entry[];
+}>;
+export declare type TaskDurationReturnType = Promise<{
+    task: {
+        duration: number;
+    };
+}>;
+export declare type TasksReturnType = Promise<{
+    days: {
+        date: string;
+        dateText: string;
+        duration: number;
+        durationText: string;
+        tasks: Task[];
+    }[];
+}>;
+export declare type EntryGroupsReturnType = Promise<{
+    groups: EntryGroup[];
+}>;
+export declare type EditEntryGroupsReturnType = Promise<{
+    confirmKey: string;
+    affectedEntries: number;
+} | {
+    success: true;
+    editedEntries: number;
+}>;
+export declare type DeleteEntryGroupsReturnType = Promise<{
+    confirmKey: string;
+    affectedEntries: number;
+} | {
+    success: true;
+    deletedEntries: number;
+}>;
+export declare type UserReportReturnType = Promise<{
+    userreport: UserReport;
+}>;
+export declare type UserReportsReturnType = Promise<{
+    userreports: UserReport[];
+}>;
+export declare type ClockReturnType = Promise<{
+    running: Entry;
+}>;
+export declare type ClockStopReturnType = Promise<{
+    stopped: Entry;
+    running: Entry;
+}>;
+export declare type ClockEditReturnType = Promise<{
+    updated: Entry;
+    running: Entry;
+}>;
+export declare type ClockUpdateReturnType = Promise<{
+    running: Entry;
+    services: Service[];
+    projects: Array<{
+        id: number;
+        name: string;
+        access: {
+            add: boolean;
+            edit: boolean;
+        };
+    }>;
+    billable: {
+        [key: string]: number;
+    };
+    user: User;
+}>;
+export declare type SearchTextsReturnType = Promise<{
+    texts: string[];
+}>;
+export declare type TargetHourReturnType = Promise<{
+    targethours: TargetHoursRow;
+}>;
+export declare type TargetHoursReturnType = Promise<{
+    targethours: TargetHoursRow[];
+}>;
+export declare type AddUserReturnType = Promise<{
+    success: "true";
+    user: User;
+    apikey: string;
+}>;

--- a/dist/internals/returnTypes.js
+++ b/dist/internals/returnTypes.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/internals/utilities/mapKeys.js
+++ b/dist/internals/utilities/mapKeys.js
@@ -40,7 +40,9 @@ const paramMapping = {
     countHours: "count_hours",
     billedMoney: "billed_money",
     billedCompletely: "billed_completely",
+    revenueFactor: "revenue_factor",
     confirmKey: "confirm_key",
+    editLock: "edit_lock",
     textsId: "texts_id",
 };
 function mapKeys(userParams) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./internals/api";
+export * from "./internals/interfaces";
+export * from "./internals/returnTypes";

--- a/src/internals/api.ts
+++ b/src/internals/api.ts
@@ -2,6 +2,7 @@
 
 import { ClockodoLib } from "./utilities/lib";
 import * as REQUIRED from "./utilities/requiredParams";
+import { AbsenceReturnType, AbsencesReturnType, DeleteReturnType, CustomerReturnType, CustomersReturnType, ProjectReturnType, ServiceReturnType, ServicesReturnType, UserReturnType, UsersReturnType, EntryReturnType, EntriesReturnType, TasksReturnType, TaskDurationReturnType, DeleteEntryGroupsReturnType, EditEntryGroupsReturnType, UserReportReturnType, UserReportsReturnType, ClockReturnType, ClockUpdateReturnType, ClockEditReturnType, ClockStopReturnType, TargetHoursReturnType, TargetHourReturnType, AddUserReturnType, SearchTextsReturnType, EntryGroupsReturnType } from "../internals/returnTypes";
 
 const clockodoApi = Symbol("api");
 
@@ -46,43 +47,43 @@ export class Clockodo {
         this[clockodoApi] = new ClockodoLib(user, apiKey);
     }
 
-    async getAbsence({ id }: { id: string }) {
+    async getAbsence({ id }: { id: string }): AbsenceReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_ABSENCE);
 
         return this[clockodoApi].get("/absences/" + id);
     }
 
-    async getAbsences({ year }: { year: number }) {
+    async getAbsences({ year }: { year: number }): AbsencesReturnType {
         REQUIRED.checkRequired({ year }, REQUIRED.GET_ABSENCES);
 
         return this[clockodoApi].get("/absences", { year });
     }
 
-    async getClock() {
+    async getClock(): ClockReturnType {
         return this[clockodoApi].get("/clock");
     }
 
-    async getClockUpdate() {
+    async getClockUpdate(): ClockUpdateReturnType {
         return this[clockodoApi].get("/clock/update");
     }
 
-    async getCustomer({ id }: { id: string }) {
+    async getCustomer({ id }: { id: string }): CustomerReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_CUSTOMER);
 
         return this[clockodoApi].get("/customers/" + id);
     }
 
-    async getCustomers() {
+    async getCustomers(): CustomersReturnType {
         return this[clockodoApi].get("/customers");
     }
 
-    async getEntry({ id }: { id: string }) {
+    async getEntry({ id }: { id: string }): EntryReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_ENTRY);
 
         return this[clockodoApi].get("/entries/" + id);
     }
 
-    async getEntries({ timeSince, timeUntil }: { timeSince: string; timeUntil: string }, options?: object) {
+    async getEntries({ timeSince, timeUntil }: { timeSince: string; timeUntil: string }, options?: object): EntriesReturnType {
         const requiredArguments = { timeSince, timeUntil };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.GET_ENTRIES);
@@ -93,7 +94,7 @@ export class Clockodo {
     async getEntryGroups(
         { timeSince, timeUntil, grouping }: { timeSince: string; timeUntil: string; grouping: string[] },
         options?: object
-    ) {
+    ): EntryGroupsReturnType {
         const requiredArguments = { timeSince, timeUntil, grouping };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.GET_ENTRY_GROUPS);
@@ -101,33 +102,33 @@ export class Clockodo {
         return this[clockodoApi].get("/entrygroups", { ...requiredArguments, ...options });
     }
 
-    async getProject({ id }: { id: string }) {
+    async getProject({ id }: { id: string }): ProjectReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_PROJECT);
 
         return this[clockodoApi].get("/projects/" + id);
     }
 
-    async getSearchTexts(options?: object) {
+    async getSearchTexts(options?: object): SearchTextsReturnType {
         return this[clockodoApi].get("/searchtexts", options);
     }
 
-    async getService({ id }: { id: string }) {
+    async getService({ id }: { id: string }): ServiceReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_SERVICE);
 
         return this[clockodoApi].get("/services/" + id);
     }
 
-    async getServices() {
+    async getServices(): ServicesReturnType {
         return this[clockodoApi].get("/services");
     }
 
-    async getSingleTargetHourSet({ id }: { id: string }){
+    async getSingleTargetHourSet({ id }: { id: string }): TargetHourReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_SINGLE_TARGET_HOUR_SET);
 
         return this[clockodoApi].get("/targethours/" + id);
     }
 
-    async getTargetHours(options?: object) {
+    async getTargetHours(options?: object): TargetHoursReturnType {
         return this[clockodoApi].get("/targethours", options );
     }
 
@@ -146,7 +147,7 @@ export class Clockodo {
             taskBillable: Billable;
         },
         options?: object
-    ) {
+    ): TaskDurationReturnType {
         const requiredArguments = { taskCustomerId, taskProjectId, taskServiceId, taskText, taskBillable };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.GET_TASK_DURATION);
@@ -154,27 +155,27 @@ export class Clockodo {
         return this[clockodoApi].get("/tasks/duration", { ...requiredArguments, ...options });
     }
 
-    async getTasks(options?: object) {
+    async getTasks(options?: object): TasksReturnType {
         return this[clockodoApi].get("/tasks", options);
     }
 
-    async getUser({ id }: { id: string }) {
+    async getUser({ id }: { id: string }): UserReturnType {
         REQUIRED.checkRequired({ id }, REQUIRED.GET_USER);
 
         return this[clockodoApi].get("/users/" + id);
     }
 
-    async getUsers() {
+    async getUsers(): UsersReturnType {
         return this[clockodoApi].get("/users");
     }
 
-    async getUserReport({ id, year }: { id: string; year: number }, options?: object) {
+    async getUserReport({ id, year }: { id: string; year: number }, options?: object): UserReportReturnType {
         REQUIRED.checkRequired({ id, year }, REQUIRED.GET_USER_REPORTS);
 
         return this[clockodoApi].get("/userreports/" + id, { year, ...options });
     }
 
-    async getUserReports({ year }: { year: number }, options?: object) {
+    async getUserReports({ year }: { year: number }, options?: object): UserReportsReturnType {
         REQUIRED.checkRequired({ year }, REQUIRED.GET_USER_REPORTS);
 
         return this[clockodoApi].get("/userreports", { year, ...options });
@@ -183,7 +184,7 @@ export class Clockodo {
     async changeClockDuration(
         { entryId, durationBefore, duration }: { entryId: string; durationBefore: number; duration: number },
         options?: object
-    ) {
+    ): ClockEditReturnType {
         const requiredArguments = { durationBefore, duration };
 
         REQUIRED.checkRequired({ entryId, ...requiredArguments }, REQUIRED.CHANGE_CLOCK_DURATION);
@@ -194,7 +195,7 @@ export class Clockodo {
     async startClock(
         { customerId, serviceId, billable }: { customerId: string; serviceId: string; billable: Billable },
         options?: object
-    ) {
+    ): ClockReturnType {
         const requiredArguments = { customerId, serviceId, billable };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.START_CLOCK);
@@ -202,19 +203,19 @@ export class Clockodo {
         return this[clockodoApi].post("/clock", { ...requiredArguments, ...options });
     }
 
-    async addCustomer({ name }: { name: string }, options?: object) {
+    async addCustomer({ name }: { name: string }, options?: object): CustomerReturnType {
         REQUIRED.checkRequired({ name }, REQUIRED.ADD_CUSTOMER);
 
         return this[clockodoApi].post("/customers", { name, ...options });
     }
 
-    async addProject({ name, customerId }: { name: string; customerId: string }, options?: object) {
+    async addProject({ name, customerId }: { name: string; customerId: string }, options?: object): ProjectReturnType {
         REQUIRED.checkRequired({ name, customerId }, REQUIRED.ADD_PROJECT);
 
         return this[clockodoApi].post("/projects", { name, customerId, ...options });
     }
 
-    async addService({ name }: { name: string }, options?: object) {
+    async addService({ name }: { name: string }, options?: object): ServiceReturnType {
         REQUIRED.checkRequired({ name }, REQUIRED.ADD_SERVICE);
 
         return this[clockodoApi].post("/services", { name, ...options });
@@ -223,7 +224,7 @@ export class Clockodo {
     async addUser(
         { name, number, email, role }: { name: string; number: string; email: string; role: string },
         options?: object
-    ) {
+    ): AddUserReturnType {
         const requiredArguments = { name, number, email, role };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.ADD_USER);
@@ -234,7 +235,7 @@ export class Clockodo {
     async addEntry(
         { customerId, serviceId, billable }: { customerId: string; serviceId: string; billable: Billable },
         options?: object
-    ) {
+    ): EntryReturnType {
         const requiredArguments = { customerId, serviceId, billable };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.ADD_ENTRY);
@@ -245,7 +246,7 @@ export class Clockodo {
     async addAbsence(
         { dateSince, dateUntil, type }: { dateSince: string; dateUntil: string; type: AbsenceType },
         options?: object
-    ) {
+    ): AbsenceReturnType {
         const requiredArguments = { dateSince, dateUntil, type };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.ADD_ABSENCE);
@@ -253,43 +254,43 @@ export class Clockodo {
         return this[clockodoApi].post("/absences", { ...requiredArguments, ...options });
     }
 
-    async stopClock({ entryId }: { entryId: string }, options?: object) {
+    async stopClock({ entryId }: { entryId: string }, options?: object): ClockStopReturnType {
         REQUIRED.checkRequired({ entryId }, REQUIRED.STOP_CLOCK);
 
         return this[clockodoApi].delete("/clock/" + entryId, options);
     }
 
-    async deactivateCustomer({ customerId }: { customerId: string }, options?: object) {
+    async deactivateCustomer({ customerId }: { customerId: string }, options?: object): CustomerReturnType {
         REQUIRED.checkRequired({ customerId }, REQUIRED.DEACTIVATE_CUSTOMER);
 
         return this[clockodoApi].delete("/customers/" + customerId, options);
     }
 
-    async deactivateProject({ projectId }: { projectId: string }, options?: object) {
+    async deactivateProject({ projectId }: { projectId: string }, options?: object): ProjectReturnType {
         REQUIRED.checkRequired({ projectId }, REQUIRED.DEACTIVATE_PROJECT);
 
         return this[clockodoApi].delete("/projects/" + projectId, options);
     }
 
-    async deactivateService({ serviceId }: { serviceId: string }, options?: object) {
+    async deactivateService({ serviceId }: { serviceId: string }, options?: object): ServiceReturnType {
         REQUIRED.checkRequired({ serviceId }, REQUIRED.DEACTIVATE_SERVICE);
 
         return this[clockodoApi].delete("/services/" + serviceId, options);
     }
 
-    async deactivateUser({ userId }: { userId: string }, options?: object) {
+    async deactivateUser({ userId }: { userId: string }, options?: object): UserReturnType {
         REQUIRED.checkRequired({ userId }, REQUIRED.DEACTIVATE_USER);
 
         return this[clockodoApi].delete("/users/" + userId, options);
     }
 
-    async deleteEntry({ entryId }: { entryId: string }, options?: object) {
+    async deleteEntry({ entryId }: { entryId: string }, options?: object): DeleteReturnType {
         REQUIRED.checkRequired({ entryId }, REQUIRED.DELETE_ENTRY);
 
         return this[clockodoApi].delete("/entries/" + entryId, options);
     }
 
-    async deleteEntryGroup({ timeSince, timeUntil }: { timeSince: string; timeUntil: string }, options?: object) {
+    async deleteEntryGroup({ timeSince, timeUntil }: { timeSince: string; timeUntil: string }, options?: object): DeleteEntryGroupsReturnType {
         const requiredArguments = { timeSince, timeUntil };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.DELETE_ENTRY_GROUP);
@@ -297,7 +298,7 @@ export class Clockodo {
         return this[clockodoApi].delete("/entrygroups", { ...requiredArguments, ...options });
     }
 
-    async deleteAbsence({ absenceId }: { absenceId: string }, options?: object) {
+    async deleteAbsence({ absenceId }: { absenceId: string }, options?: object): DeleteReturnType {
         REQUIRED.checkRequired({ absenceId }, REQUIRED.DELETE_ABSENCE);
 
         return this[clockodoApi].delete("/absences/" + absenceId, options);
@@ -309,25 +310,25 @@ export class Clockodo {
         return this[clockodoApi].put("/customers/" + customerId, options);
     }
 
-    async editProject({ projectId }: { projectId: string }, options?: object) {
+    async editProject({ projectId }: { projectId: string }, options?: object): ProjectReturnType {
         REQUIRED.checkRequired({ projectId }, REQUIRED.EDIT_PROJECT);
 
         return this[clockodoApi].put("/projects/" + projectId, options);
     }
 
-    async editService({ serviceId }: { serviceId: string }, options?: object) {
+    async editService({ serviceId }: { serviceId: string }, options?: object): ServiceReturnType {
         REQUIRED.checkRequired({ serviceId }, REQUIRED.EDIT_SERVICE);
 
         return this[clockodoApi].put("/services/" + serviceId, options);
     }
 
-    async editUser({ userId }: { userId: string }, options?: object) {
+    async editUser({ userId }: { userId: string }, options?: object): UserReturnType {
         REQUIRED.checkRequired({ userId }, REQUIRED.EDIT_USER);
 
         return this[clockodoApi].put("/users/" + userId, options);
     }
 
-    async editEntryGroup({ timeSince, timeUntil }: { timeSince: string; timeUntil: string }, options?: object) {
+    async editEntryGroup({ timeSince, timeUntil }: { timeSince: string; timeUntil: string }, options?: object): EditEntryGroupsReturnType {
         const requiredArguments = { timeSince, timeUntil };
 
         REQUIRED.checkRequired(requiredArguments, REQUIRED.EDIT_ENTRY_GROUP);
@@ -335,13 +336,13 @@ export class Clockodo {
         return this[clockodoApi].put("/entrygroups", { ...requiredArguments, ...options });
     }
 
-    async editAbsence({ absenceId }: { absenceId: string }, options?: object) {
+    async editAbsence({ absenceId }: { absenceId: string }, options?: object): AbsenceReturnType {
         REQUIRED.checkRequired({ absenceId }, REQUIRED.EDIT_ABSENCE);
 
         return this[clockodoApi].put("/absences/" + absenceId, options);
     }
 
-    async editEntry({ entryId }: { entryId: string }, options?: object) {
+    async editEntry({ entryId }: { entryId: string }, options?: object): EntryReturnType {
         REQUIRED.checkRequired({ entryId }, REQUIRED.EDIT_ENTRY);
 
         return this[clockodoApi].put("/entries/" + entryId, options);

--- a/src/internals/interfaces.ts
+++ b/src/internals/interfaces.ts
@@ -151,7 +151,7 @@ export interface UserReportWeek {
     sumHours: number,
     sumReductionUsed: number,
     diff: number,
-    weekDetails: UserReportDay[],
+    dayDetails: UserReportDay[],
 }
 
 export interface Break {

--- a/src/internals/interfaces.ts
+++ b/src/internals/interfaces.ts
@@ -1,0 +1,266 @@
+export interface Customer {
+    id: number,
+    name: string,
+    number: string,
+    active: boolean,
+    billableDefault: boolean,
+    note: string,
+    projects: Project[],
+}
+
+export interface Project {
+    id: number,
+    customerId: number,
+    name: string,
+    active: boolean,
+    billableDefault: boolean,
+    note: string,
+    budgetMoney: number,
+    budgetIsHours: boolean,
+    budgetIsNotStrict: boolean,
+    completed: boolean,
+    billedMoney: number,
+    billedCompletely: boolean,
+    revenueFactor: number,
+}
+
+export interface Service {
+    id: number,
+    name: string,
+    number: string,
+    active: boolean,
+    note: string,
+}
+
+export interface User {
+    id: number,
+    name: string,
+    number: string,
+    email: string,
+    role: string,
+    active: boolean,
+    editLock: string,
+}
+
+export interface Entry {
+    id:number,
+    customerId: number,
+    projectId: number,
+    userId: number,
+    serviceId: number,
+    billable: 0 | 1,
+    billed: boolean,
+    textId: number,
+    text: string,
+    duration: number,
+    durationTime: string,
+    offset: number,
+    offsetTime: string,
+    timeSince: string,
+    timeUntil: string,
+    timeInsert: string,
+    timeLastChange: string,
+    timeLastChangeWorktime: string,
+    clocked: boolean,
+    isClocking: boolean,
+    lumpSum: number,
+    hourlyRate?: number,
+    revenue?: number,
+    budget?: number,
+    budgetIsHours?: boolean,
+    budgetIsNotStrict?: boolean,
+    customerName?: string,
+    projectName?: string,
+    serviceName?: string,
+    userName?: string,
+}
+
+export interface Task {
+    day: string,
+    customerId: number,
+    customerName: string,
+    projectId: number,
+    projectName: string,
+    serviceId: number,
+    serviceName: string,
+    billable: number,
+    textId: number,
+    text: string,
+    duration: number,
+    durationTime: string,
+    durationText: string,
+    isClocking: boolean,
+    hasJustLumpSums: boolean,
+    revenue?: number,
+}
+
+export interface EntryGroup {
+    groupeyby: string,
+    group: string,
+    name: string,
+    number: string,
+    note: string,
+    restrictions: string[],
+    duration: number,
+    revenue?: number,
+    budgetUsed?: boolean,
+    hasBudgetRevenuesBilled?: boolean,
+    hasBudgetRevenuesNotBilled?: boolean,
+    hasNonBudgetRevenuesBilled?: boolean,
+    hasNonBudgetRevenuesNotBilled?: boolean,
+    hourlyRate?: number,
+    hourlyRateIsEqualAndHasNoLumpSums?: boolean,
+    durationWithoutRounding?: number,
+    revenueWithoutRounding?: number,
+    roundingSuccess?: boolean,
+    subGroups: EntryGroup[],
+}
+
+export interface UserReport {
+    userId: number,
+    userName: string,
+    sumTarget: number,
+    sumHours: number,
+    sumReductionUsed: number,
+    sumReductionPlanned: number,
+    overtimeCarryover: number,
+    overtimeReduced: number,
+    diff: number,
+    holidaysQuota: number,
+    holidaysCarry: number,
+    holidaysUsed: number,
+    specialHolidays: number,
+    sickdays: number,
+    monthDetails: UserReportMonth[],
+}
+
+export interface UserReportMonth {
+    nr: number,
+    sumTarget: number,
+    sumHours: number,
+    sumHoursWithoutCompensation: number,
+    sumReductionUsed: number,
+    sumOvertimeReduced: number,
+    diff: number,
+    weekDetails: UserReportWeek[],
+}
+
+export interface UserReportWeek {
+    nr: number,
+    sumTarget: number,
+    sumHours: number,
+    sumReductionUsed: number,
+    diff: number,
+    weekDetails: UserReportDay[],
+}
+
+export interface Break {
+    since: string,
+    until: string,
+    length: number,
+}
+
+export interface UserReportDay {
+    date: string,
+    weekday: number,
+    nonbusiness: boolean,
+    countSick: number,
+    countRegularHolidays: number,
+    countSpecialLeaves: number,
+    countHolidas: number,
+    countOtReductionUsed: number,
+    target: number,
+    targetRaw: number,
+    hours: number,
+    hoursWithoutCompensation: number,
+    diff: number,
+    workStart: string,
+    workEnd: string,
+    breaks: Break[],
+}
+
+export interface Absence {
+    id: number,
+    userId: number,
+    dateSince: string,
+    dateUntil: string,
+    status: number,
+    type: number,
+    note: string,
+    countDays: number,
+    countHours: number,
+    dateEnquired: string,
+    dateApproved: string,
+    approvedBy: number,
+}
+
+export interface TargetHoursRow {
+    id: number,
+    userId: number,
+    type: string,
+    dateSince: string,
+    dateUntil: string | null,
+    monday: number,
+    tuesday: number,
+    wednesday: number,
+    thursday: number,
+    friday: number,
+    saturday: number,
+    sunday: number,
+    absenceFixedCredit: boolean,
+    compensationDaily: number,
+    compensationMonthly: number,
+    monthlyTarget: number,
+    workdayMonday: boolean,
+    workdayTuesday: boolean,
+    workdayWednesday: boolean,
+    workdayThursday: boolean,
+    workdayFriday: boolean,
+    workdaySaturday: boolean,
+    workdaySunday: boolean,
+}
+
+export interface HolidayQuotasRow {
+    id: number,
+    userId: number,
+    yearSince: number,
+    yearUntil: number,
+    count: number,
+}
+
+export interface HolidaysCarryRow {
+    userId: number,
+    year: number,
+    count: number,
+    note: string,
+}
+
+export interface User {
+    name: string,
+    email: string,
+    role: string,
+    timeformat12h: boolean,
+    weekstartMonday: boolean,
+    language: string,
+    currency: string,
+    currencySymbol: string,
+    timezone: string,
+}
+
+export interface Paging {
+    itemsPerPage: number,
+    currentPage: number,
+    countPages: number,
+    countItems: number,
+}
+
+export interface Filter {
+    userId?: number,
+    customerId?: number,
+    projectId?: number,
+    serviceId?: number,
+    billable?: number,
+    text?: string,
+    textId?: number,
+    budgetType?: string,
+}

--- a/src/internals/interfaces.ts
+++ b/src/internals/interfaces.ts
@@ -10,7 +10,7 @@ export interface Customer {
 
 export interface Project {
     id: number,
-    customerId: number,
+    customersId: number,
     name: string,
     active: boolean,
     billableDefault: boolean,
@@ -44,13 +44,13 @@ export interface User {
 
 export interface Entry {
     id:number,
-    customerId: number,
-    projectId: number,
-    userId: number,
-    serviceId: number,
+    customersId: number,
+    projectsId: number,
+    usersId: number,
+    servicesId: number,
     billable: 0 | 1,
     billed: boolean,
-    textId: number,
+    textsId: number,
     text: string,
     duration: number,
     durationTime: string,
@@ -77,14 +77,14 @@ export interface Entry {
 
 export interface Task {
     day: string,
-    customerId: number,
-    customerName: string,
-    projectId: number,
-    projectName: string,
-    serviceId: number,
-    serviceName: string,
+    customersId: number,
+    customersName: string,
+    projectsId: number,
+    projectsName: string,
+    servicesId: number,
+    servicesName: string,
     billable: number,
-    textId: number,
+    textsId: number,
     text: string,
     duration: number,
     durationTime: string,
@@ -117,8 +117,8 @@ export interface EntryGroup {
 }
 
 export interface UserReport {
-    userId: number,
-    userName: string,
+    usersId: number,
+    usersName: string,
     sumTarget: number,
     sumHours: number,
     sumReductionUsed: number,
@@ -181,7 +181,7 @@ export interface UserReportDay {
 
 export interface Absence {
     id: number,
-    userId: number,
+    usersId: number,
     dateSince: string,
     dateUntil: string,
     status: number,
@@ -196,7 +196,7 @@ export interface Absence {
 
 export interface TargetHoursRow {
     id: number,
-    userId: number,
+    usersId: number,
     type: string,
     dateSince: string,
     dateUntil: string | null,
@@ -222,14 +222,14 @@ export interface TargetHoursRow {
 
 export interface HolidayQuotasRow {
     id: number,
-    userId: number,
+    usersId: number,
     yearSince: number,
     yearUntil: number,
     count: number,
 }
 
 export interface HolidaysCarryRow {
-    userId: number,
+    usersId: number,
     year: number,
     count: number,
     note: string,
@@ -255,12 +255,12 @@ export interface Paging {
 }
 
 export interface Filter {
-    userId?: number,
-    customerId?: number,
-    projectId?: number,
-    serviceId?: number,
+    usersId?: number,
+    customersId?: number,
+    projectsId?: number,
+    servicesId?: number,
     billable?: number,
     text?: string,
-    textId?: number,
+    textsId?: number,
     budgetType?: string,
 }

--- a/src/internals/interfaces.ts
+++ b/src/internals/interfaces.ts
@@ -96,7 +96,7 @@ export interface Task {
 
 export interface EntryGroup {
     groupeyby: string,
-    group: string,
+    group: string | number,
     name: string,
     number: string,
     note: string,

--- a/src/internals/interfaces.ts
+++ b/src/internals/interfaces.ts
@@ -69,10 +69,10 @@ export interface Entry {
     budget?: number,
     budgetIsHours?: boolean,
     budgetIsNotStrict?: boolean,
-    customerName?: string,
-    projectName?: string,
-    serviceName?: string,
-    userName?: string,
+    customersName?: string,
+    projectsName?: string,
+    servicesName?: string,
+    usersName?: string,
 }
 
 export interface Task {

--- a/src/internals/returnTypes.ts
+++ b/src/internals/returnTypes.ts
@@ -1,0 +1,43 @@
+import { Absence, Customer, Project, Service, User, Entry, Paging, Filter, Task, EntryGroup, UserReport, TargetHoursRow } from "./interfaces";
+
+export type AbsenceReturnType = Promise<{ absence: Absence }>;
+export type AbsencesReturnType = Promise<{ absences: Absence[] }>;
+export type DeleteReturnType = Promise<{ success: true }>;
+export type CustomerReturnType = Promise<{ customer: Customer }>;
+export type CustomersReturnType = Promise<{ customers: Customer[] }>;
+export type ProjectReturnType = Promise<{ project: Project }>;
+export type ServiceReturnType = Promise<{ service: Service }>;
+export type ServicesReturnType = Promise<{ services: Service[] }>;
+export type UserReturnType = Promise<{ user: User }>;
+export type UsersReturnType = Promise<{ users: User[] }>;
+export type EntryReturnType = Promise<{ entry: Entry }>;
+export type EntriesReturnType = Promise<{ paging: Paging, filter: Filter | null, entries: Entry[] }>;
+export type TaskDurationReturnType = Promise<{ task: { duration: number } }>;
+export type TasksReturnType = Promise<{
+    days: {
+        date: string,
+        dateText: string,
+        duration: number,
+        durationText: string,
+        tasks: Task[],
+    }[],
+}>;
+export type EntryGroupsReturnType = Promise<{ groups: EntryGroup[] }>;
+export type EditEntryGroupsReturnType = Promise<{ confirmKey: string, affectedEntries: number } | { success: true, editedEntries: number }>;
+export type DeleteEntryGroupsReturnType = Promise<{ confirmKey: string, affectedEntries: number } | { success: true, deletedEntries: number }>;
+export type UserReportReturnType = Promise<{ userreport: UserReport }>;
+export type UserReportsReturnType = Promise<{ userreports: UserReport[] }>;
+export type ClockReturnType = Promise<{ running: Entry }>;
+export type ClockStopReturnType = Promise<{ stopped: Entry, running: Entry }>;
+export type ClockEditReturnType = Promise<{ updated: Entry, running: Entry }>;
+export type ClockUpdateReturnType = Promise<{
+    running: Entry,
+    services: Service[],
+    projects: Array<{ id: number, name: string, access: { add: boolean, edit: boolean } }>
+    billable: { [key: string]: number },
+    user: User,
+}>;
+export type SearchTextsReturnType = Promise<{ texts: string[] }>;
+export type TargetHourReturnType = Promise<{ targethours: TargetHoursRow }>;
+export type TargetHoursReturnType = Promise<{ targethours: TargetHoursRow[] }>;
+export type AddUserReturnType = Promise<{ success: "true", user: User, apikey: string }>;

--- a/src/internals/utilities/mapKeys.ts
+++ b/src/internals/utilities/mapKeys.ts
@@ -40,7 +40,9 @@ const paramMapping = {
     countHours: "count_hours",
     billedMoney: "billed_money",
     billedCompletely: "billed_completely",
+    revenueFactor: "revenue_factor",
     confirmKey: "confirm_key",
+    editLock: "edit_lock",
     textsId: "texts_id",
 };
 


### PR DESCRIPTION
closes #27 

I am currently in the processing of converting checkodo to typescript and noticed that I need the return types typed in clockodo itself. It doesn't make sense to do that in checkodo. I went through the api docs and added interfaces for all entities. Then added return types `type`s for each api function. where the api docs specify what is supposed to be returned.

I went through it all carefully and hope not to have made any typing mistakes. I used the converted keys that are output after calling map keys and camelcase. Maybe a test run with the new typings in checkodo could help to find irregularities. Otherwise maybe a beta release with these typings would already help me in continuing converting checkodo.

Also, are the typings included correctly?