### PR TITLE
fix: Wrong URL being used in getSearchTexts()

### DIFF
--- a/src/internals/clockodo.ts
+++ b/src/internals/clockodo.ts
@@ -164,7 +164,7 @@ export class Clockodo {
     getSearchTexts = async (
         options?: Record<string, unknown>
     ): SearchTextsReturnType => {
-        return this.api.get("/searchtexts", options);
+        return this.api.get("/clock/searchtexts", options);
     };
 
     getService = async ({ id }: { id: number }): ServiceReturnType => {

--- a/tests/unit/unit.test.ts
+++ b/tests/unit/unit.test.ts
@@ -289,7 +289,7 @@ describe("Clockodo (instance)", () => {
                 };
 
                 const nockScope = nock(CLOCKODO_API)
-                    .get("/searchtexts?" + qs.stringify(expectedParameters))
+                    .get("/clock/searchtexts?" + qs.stringify(expectedParameters))
                     .reply(200);
 
                 await clockodo.getSearchTexts(givenParameters);


### PR DESCRIPTION
When calling `clockodoApi.getSearchTexts({ term:'test123'})` the following error is shown: `Unhandled error: Error: Request failed with status code 404`. 

When looking the the official Clockodo API, we saw that the url that is being used to access the searchTexts is : `/api/clock/searchtexts`

In the PR, when adding the 'clock' string, the correct data is returned. 