### PR TITLE
feat: Refactor paginated endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ const clockodo = new Clockodo({
     // You need to add some information about yourself that will be
     // sent along every request,
     // see https://www.clockodo.com/en/api/ "Client identification"
-    name: "The name of your application or your company",
+    // PLEASE NOTE: name + ";" + email must not be longer than 50 characters.
+    name: "Your application/company",
     email: "technical-contact@your-company.com",
   },
   authentication: {

--- a/README.md
+++ b/README.md
@@ -152,12 +152,29 @@ await clockodo.getCustomer({ id: 777 });
 
 ### getCustomers()
 
-Get list of customers
+Get all customers from all pages.
 
 #### Example:
 
 ```js
 await clockodo.getCustomers();
+// or
+await clockodo.getCustomers({
+  // Filter by active flag
+  filterActive: true,
+});
+```
+
+---
+
+### getCustomersPage()
+
+Get all customers from a specific page.
+
+#### Example:
+
+```js
+await clockodo.getCustomersPage({ page: 2 });
 ```
 
 ---
@@ -176,7 +193,7 @@ await clockodo.getEntry({ id: 4 });
 
 ### getEntries()
 
-Gets list of Clockodo activity entries.
+Get all entries from all pages.
 
 #### Example:
 
@@ -184,9 +201,27 @@ Gets list of Clockodo activity entries.
 import { Billability } from "clockodo";
 
 await clockodo.getEntries({
+  // timeSince and timeUntil are required
   timeSince: "2017-08-18T00:00:00Z",
   timeUntil: "2018-02-09T00:00:00Z",
+  // You can also add additional filters here
   filterBillable: Billability.Billed,
+});
+```
+
+---
+
+### getEntriesPage()
+
+Get all entries from a specific page
+
+#### Example:
+
+```js
+await clockodo.getEntriesPage({
+  timeSince: "2017-08-18T00:00:00Z",
+  timeUntil: "2018-02-09T00:00:00Z",
+  page: 2,
 });
 ```
 
@@ -211,7 +246,7 @@ await clockodo.getEntryGroups({
 
 ### getEntriesTexts()
 
-Retreive descriptions (and no additional info) entered for time and lump sum entries. Seems to be a tight but case insensitive match.
+Retreive all descriptions (and no additional info) entered for time and lump sum entries from all pages.
 
 #### Example:
 
@@ -221,9 +256,21 @@ await clockodo.getEntriesTexts({ text: "meeting with client" });
 
 ---
 
+### getEntriesTextsPage()
+
+Retreive all descriptions from a specific page.
+
+#### Example:
+
+```js
+await clockodo.getEntriesTextsPage({ text: "meeting with client", page: 2 });
+```
+
+---
+
 ### getProject()
 
-Get a project by its ID. For a list of projects, use getCustomers().
+Get a project by its ID.
 
 #### Example:
 
@@ -235,16 +282,31 @@ await clockodo.getProject({ id: 1985 });
 
 ### getProjects()
 
-Returns all projects.
+Get all projects from all pages.
 
 #### Example:
 
 ```js
 await clockodo.getProjects();
-// or filter by a specific customer id
+// or
 await clockodo.getProjects({
+  // Filter by a specific customer id
   filterCustomersId: 123,
+  // Filter by active flag
+  filterActive: true,
 });
+```
+
+---
+
+### getProjectsPage()
+
+Get all projects from a specific page.
+
+#### Example:
+
+```js
+await clockodo.getProjectsPage({ page: 2 });
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@faker-js/faker": "^7.2.0",
         "axios": "^0.21.4",
         "map-obj": "^5.0.1",
+        "p-limit": "^4.0.0",
         "qs": "^6.10.5"
       },
       "devDependencies": {
@@ -9817,15 +9818,17 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dependencies": {
-        "p-try": "^1.0.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -9835,6 +9838,18 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
@@ -12256,6 +12271,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -19493,12 +19519,11 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "requires": {
-        "p-try": "^1.0.0"
+        "yocto-queue": "^1.0.0"
       }
     },
     "p-locate": {
@@ -19508,6 +19533,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        }
       }
     },
     "p-map": {
@@ -21333,6 +21369,11 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@faker-js/faker": "^7.2.0",
     "axios": "^0.21.4",
     "map-obj": "^5.0.1",
+    "p-limit": "^4.0.0",
     "qs": "^6.10.5"
   },
   "devDependencies": {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -10,7 +10,7 @@ const hasCredentials =
   typeof process.env.CLOCKODO_API_KEY === "string";
 const config: Config = {
   client: {
-    name: "Clockodo SDK Integration Test",
+    name: "SDK Integration Test",
     email: "johannes.ewald@peerigon.com",
   },
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,12 @@
 import axios, { AxiosRequestConfig } from "axios";
 import qs from "qs";
+import pLimit from "p-limit";
 import { axiosClient } from "./symbols.js";
 import { mapQueryParams, mapRequestBody, mapResponseBody } from "./mappings.js";
+import { Billability } from "../models/entry.js";
 
 const DEFAULT_BASE_URL = "https://my.clockodo.com/api";
+const MAX_PARALLEL_REQUESTS_WHEN_STREAMING = 3;
 
 const paramsSerializer = (params: Record<string, string>) => {
   const urlParams = [];
@@ -28,18 +31,31 @@ export type Paging = {
   countItems: number;
 };
 
+type BooleanAsNumber = 0 | 1;
+
 export type Filter = {
-  usersId?: number;
-  customersId?: number;
-  projectsId?: number;
-  servicesId?: number;
-  lumpsumServicesId?: number;
-  billable?: number;
-  text?: string;
-  textsId?: number;
-  budgetType?: string;
-  timeSince?: string;
-  timeUntil?: string;
+  usersId: number;
+  customersId: number;
+  projectsId: number;
+  servicesId: number;
+  lumpsumServicesId: number;
+  billable: Billability;
+  text: string;
+  textsId: number;
+  budgetType: string;
+  timeSince: string;
+  timeUntil: string;
+  active: BooleanAsNumber;
+};
+
+export type ResponseWithPaging = {
+  paging: Paging;
+};
+
+export type ResponseWithoutPaging<Response> = Omit<Response, "paging">;
+
+export type ResponseWithFilter<FilterProperty extends keyof Filter> = {
+  filter: null | Partial<Pick<Filter, FilterProperty>>;
 };
 
 export type Authentication = {
@@ -205,6 +221,49 @@ export class Api {
     return mapResponseBody<Result>(response.data);
   }
 
+  async *getPagesStreaming<Result extends ResponseWithPaging>(
+    ...args: Parameters<Api["get"]>
+  ) {
+    const [url, queryParams = {}, options] = args;
+    const getPage = async (page: number) => {
+      return this.get<Result & ResponseWithPaging>(
+        url,
+        { ...queryParams, page },
+        options
+      );
+    };
+    const firstResponse = await getPage(1);
+
+    yield firstResponse;
+
+    const { paging } = firstResponse;
+    const limit = pLimit(MAX_PARALLEL_REQUESTS_WHEN_STREAMING);
+    const remainingPages = Array.from(
+      { length: paging.countPages - 1 },
+      (_, index) => index + 2
+    );
+
+    yield* yieldPagesAsap(
+      remainingPages.map(async (page) => limit(getPage, page))
+    );
+  }
+
+  async getAllPages<Result extends ResponseWithPaging>(
+    ...args: Parameters<Api["get"]>
+  ): Promise<Array<Result>> {
+    const pages: Array<Result> = [];
+
+    for await (const page of this.getPagesStreaming<Result>(...args)) {
+      pages.push(page);
+    }
+
+    pages.sort(
+      (pageA, pageB) => pageA.paging.currentPage - pageB.paging.currentPage
+    );
+
+    return pages;
+  }
+
   async post<Result = any>(
     url: string,
     body = {},
@@ -259,4 +318,24 @@ const createTypeError = ({
   return new TypeError(
     `${name} should be ${expected} but given value ${actual} is typeof ${typeof actual}`
   );
+};
+
+const yieldPagesAsap = async function* <Result>(
+  pagePromises: Array<Promise<Result>>
+) {
+  const pending = new Map(
+    pagePromises.map((promise, index) => [
+      index,
+      promise.then((result) => [index, result] as const),
+    ])
+  );
+
+  while (pending.size > 0) {
+    // eslint-disable-next-line no-await-in-loop
+    const [index, result] = await Promise.race(pending.values());
+
+    pending.delete(index);
+
+    yield result;
+  }
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,6 +7,7 @@ import { Billability } from "../models/entry.js";
 
 const DEFAULT_BASE_URL = "https://my.clockodo.com/api";
 const MAX_PARALLEL_REQUESTS_WHEN_STREAMING = 3;
+const EXTERNAL_APPLICATION_HEADER_MAX_LENGTH = 50;
 
 const paramsSerializer = (params: Record<string, string>) => {
   const urlParams = [];
@@ -170,7 +171,15 @@ export class Api {
         });
       }
 
-      defaults.headers["X-Clockodo-External-Application"] = `${name};${email}`;
+      const externalApplication = `${name};${email}`;
+
+      if (externalApplication.length > EXTERNAL_APPLICATION_HEADER_MAX_LENGTH) {
+        throw new Error(
+          `External application header "${externalApplication}" is longer than ${EXTERNAL_APPLICATION_HEADER_MAX_LENGTH} characters (was ${externalApplication.length}). Please use a shorter name.`
+        );
+      }
+
+      defaults.headers["X-Clockodo-External-Application"] = externalApplication;
     }
     if ("authentication" in config) {
       const { authentication } = config;

--- a/src/lib/mappings.test.ts
+++ b/src/lib/mappings.test.ts
@@ -52,7 +52,9 @@ describe("mapResponseBody()", () => {
 });
 
 const expectKeysToMatch = (keysA: Array<string>, keysB: Array<string>) => {
-  expect(keysA.sort()).toMatchObject(keysB.sort());
+  expect(Array.from(new Set(keysA)).sort()).toMatchObject(
+    Array.from(new Set(keysB)).sort()
+  );
 };
 
 const createObjectFromKeys = (keys: Array<string>) =>

--- a/src/lib/mappings.ts
+++ b/src/lib/mappings.ts
@@ -9,14 +9,17 @@ export const queryParamMapping: Record<string, string> = {
   filterCustomersId: "filter[customers_id]",
   filterProjectsId: "filter[projects_id]",
   filterServicesId: "filter[services_id]",
+  filterLumpsumServicesId: "filter[lumpsum_services_id]",
+  /** @deprecated Please don't use this anymore, it will be removed someday */
+  filterLumpsumsServicesId: "filter[lumpsum_services_id]",
   filterBillable: "filter[billable]",
   filterText: "filter[text]",
   filterTextsId: "filter[texts_id]",
   filterBudgetType: "filter[budget_type]",
   filterLumpsumsId: "filter[lumpsums_id]",
-  filterLumpsumsServicesId: "filter[lumpsum_services_id]",
   filterTimeSince: "filter[time_since]",
   filterTimeUntil: "filter[time_until]",
+  filterActive: "filter[active]",
   // excludeIds needs to stay in camelCase.
   // This seems to be an inconsistency in the API.
   excludeIds: "excludeIds",


### PR DESCRIPTION
Methods that request paginated endpoints will now request every page
automatically. As an example: after switching to v2, getCustomers()
did not return all customers anymore. It only returned all customers
from the first page. With this change, the following methods will
automatically request all pages:

- getCustomers()
- getProjects()
- getEntries()
- getEntriesTexts()

In order to get each page indiviually, please use:

- getCustomersPage()
- getProjectsPage()
- getEntriesPage()
- getEntriesTextsPage()

BREAKING CHANGE: getCustomers(), getProjects(), getEntries(),
getEntriesTexts() won't return a paging property anymore since pages
are now requested automatically.

BREAKING CHANGE: We've also improved some typings for these endpoints
which might break your TypeScript build.