### PR TITLE
feat: support omitting billable from start clock to use it from project/customer settings

### DIFF
--- a/src/clockodo.test.ts
+++ b/src/clockodo.test.ts
@@ -621,9 +621,8 @@ describe("Clockodo (instance)", () => {
           // @ts-expect-error Intentional error just for the test
           clockodo.startClock({
             customersId: 24,
-            servicesId: 7,
           })
-        ).rejects.toThrowError('Missing required parameter "billable"');
+        ).rejects.toThrowError('Missing required parameter "servicesId"');
       });
     });
 

--- a/src/clockodo.ts
+++ b/src/clockodo.ts
@@ -447,7 +447,7 @@ export class Clockodo {
   async startClock(
     params: Params<
       Pick<TimeEntry, typeof REQUIRED.START_CLOCK[number]> & {
-        billable: ClockingTimeEntryBillability;
+        billable: ClockingTimeEntryBillability | undefined;
       }
     >
   ): Promise<ClockStartReturnType> {

--- a/src/clockodo.ts
+++ b/src/clockodo.ts
@@ -447,7 +447,11 @@ export class Clockodo {
   async startClock(
     params: Params<
       Pick<TimeEntry, typeof REQUIRED.START_CLOCK[number]> & {
-        billable: ClockingTimeEntryBillability | undefined;
+        /**
+         * Billability of the time entry that is about to be created.
+         * Omit it if you want to use the project's default.
+         */
+        billable?: ClockingTimeEntryBillability;
       }
     >
   ): Promise<ClockStartReturnType> {

--- a/src/lib/requiredParams.ts
+++ b/src/lib/requiredParams.ts
@@ -66,7 +66,7 @@ export const GET_USER_REPORT = ["usersId", "year"] as const;
 export const GET_USER_REPORTS = ["year"] as const;
 export const GET_NONBUSINESS_DAYS = ["nonbusinessgroupsId", "year"] as const;
 export const REGISTER = ["companiesName", "name", "email"] as const;
-export const START_CLOCK = ["customersId", "servicesId", "billable"] as const;
+export const START_CLOCK = ["customersId", "servicesId"] as const;
 export const STOP_CLOCK = ["entriesId"] as const;
 
 export const ADD_WORK_TIMES_CHANGE_REQUEST = [


### PR DESCRIPTION
Feature described in #116 