### PR TITLE
fix: make top-level props accept boolean

### DIFF
--- a/src/models/access.ts
+++ b/src/models/access.ts
@@ -1,5 +1,5 @@
 export type AccessToCustomersProjects =
-  | true
+  | boolean
   | Record<string, true | { projects: Record<string, true> }>;
 
 export type AccessToServices = boolean | Record<string, true>;


### PR DESCRIPTION
the top-level properties `add`, `edit` and `report` can return either a boolean or a nested structure