### PR TITLE
chore: Remove test for turkish locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "build:tsc": "tsc",
     "test": "run-p test:*",
     "test:suite": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
-    "test:turkish": "cross-env LANG=tr npm run test:suite -- 'integration' -t 'using a Turkish locale'",
     "test:lint": "eslint --max-warnings 0 --cache --ext js,ts --ignore-path .gitignore src",
     "test:types": "tsc --noEmit",
     "prepublishOnly": "run-s build",

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -377,30 +377,4 @@ describe("Clockodo", () => {
       expect(me).toHaveProperty("worktimeRegulation");
     });
   });
-
-  (process.env.LC_ALL === "tr" ? describe : describe.skip)(
-    "using a Turkish locale",
-    () => {
-      // The Turkish language has uncommon capitalization rules that
-      // mess with some snake_case to camelCase libraries
-      // See https://github.com/peerigon/clockodo/issues/74
-      it("transforms snake_case to camelCase correctly", async () => {
-        // Safety assertion that we're using the Turkish locale
-        expect("i".toLocaleUpperCase()).toBe("İ");
-
-        const {
-          entries: [firstEntry],
-        } = await clockodo.getEntries({
-          timeSince: TIME_SINCE,
-          timeUntil: TIME_UNTIL,
-          filterBillable: Billability.Billable,
-        });
-
-        expect(firstEntry).toMatchObject({
-          usersId: expect.any(Number),
-          customersId: expect.any(Number),
-        });
-      });
-    }
-  );
 });


### PR DESCRIPTION
LC_ALL and LANG don't work with Node >v20